### PR TITLE
fix the way to find real paprica_path

### DIFF
--- a/paprica-build_core_genomes.py
+++ b/paprica-build_core_genomes.py
@@ -109,7 +109,7 @@ pgdb_dir = os.path.expanduser(pgdb_dir)
 if ref_dir.endswith('/') == False:
     ref_dir = ref_dir + '/'
 
-paprica_path = os.path.dirname(os.path.abspath("__file__")) + '/' # The location of the actual paprica scripts.   
+paprica_path = os.path.dirname(os.path.realpath("__file__")) + '/' # The location of the actual paprica scripts.   
 ref_dir_domain = paprica_path + ref_dir + domain + '/'
 
 #%% Define some functions.

--- a/paprica-make_ref.py
+++ b/paprica-make_ref.py
@@ -155,7 +155,7 @@ except KeyError:
 if ref_dir.endswith('/') == False:
     ref_dir = ref_dir + '/'
     
-paprica_path = os.path.dirname(os.path.abspath("__file__")) + '/' # The location of the actual paprica scripts.    
+paprica_path = os.path.dirname(os.path.realpath("__file__")) + '/' # The location of the actual paprica scripts.    
 
 ref_dir_domain = paprica_path + ref_dir + domain + '/'
 

--- a/paprica-mg_run.py
+++ b/paprica-mg_run.py
@@ -61,7 +61,7 @@ cwd = os.getcwd() + '/' # The current working directory.
 if len(sys.argv) == 1:
     paprica_path = '/volumes/hd1/paprica/' # The location of the paprica scripts during testing.
 else:
-    paprica_path = os.path.dirname(os.path.abspath(__file__)) + '/' # The location of the actual paprica scripts.
+    paprica_path = os.path.dirname(os.path.realpath(__file__)) + '/' # The location of the actual paprica scripts.
 
 ## Read in command line arguments.
 

--- a/paprica-mgt_build.py
+++ b/paprica-mgt_build.py
@@ -113,7 +113,7 @@ except KeyError:
 if ref_dir.endswith('/') == False:
     ref_dir = ref_dir + '/'
 
-paprica_path = os.path.dirname(os.path.abspath("__file__")) + '/' # The location of the actual paprica scripts.  
+paprica_path = os.path.dirname(os.path.realpath("__file__")) + '/' # The location of the actual paprica scripts.  
 ref_dir = paprica_path + ref_dir
 
 #%% Download virus sequences, since they aren't used anywhere else.  Since this

--- a/paprica-mt_run.py
+++ b/paprica-mt_run.py
@@ -58,7 +58,7 @@ cwd = os.getcwd() + '/' # The current working directory.
 if len(sys.argv) == 1:
     paprica_path = '/volumes/hd1/paprica/' # The location of the paprica scripts during testing.
 else:
-    paprica_path = os.path.dirname(os.path.abspath(__file__)) + '/' # The location of the actual paprica scripts.
+    paprica_path = os.path.dirname(os.path.realpath(__file__)) + '/' # The location of the actual paprica scripts.
     
 ## Read in command line arguments.
 

--- a/paprica-place_it.py
+++ b/paprica-place_it.py
@@ -75,9 +75,9 @@ import random
 import pandas as pd
 
 try:
-    paprica_path = os.path.dirname(os.path.abspath(__file__)) + '/' # The location of the actual paprica scripts.
+    paprica_path = os.path.dirname(os.path.realpath(__file__)) + '/' # The location of the actual paprica scripts.
 except NameError:
-    paprica_path = os.path.dirname(os.path.abspath("__file__")) + '/'
+    paprica_path = os.path.dirname(os.path.realpath("__file__")) + '/'
 cwd = os.getcwd() + '/' # The current working directory.
                 
 ## Parse command line arguments.  Arguments that are unique to a run,

--- a/paprica-tally_pathways.py
+++ b/paprica-tally_pathways.py
@@ -47,9 +47,9 @@ import sys
 import os
 
 try:
-    paprica_path = os.path.dirname(os.path.abspath(__file__)) + '/' # The location of the actual paprica scripts.
+    paprica_path = os.path.dirname(os.path.realpath(__file__)) + '/' # The location of the actual paprica scripts.
 except NameError:
-    paprica_path = os.path.dirname(os.path.abspath("__file__")) + '/'
+    paprica_path = os.path.dirname(os.path.realpath("__file__")) + '/'
 
 cwd = os.getcwd() + '/'  # The current working directory
     


### PR DESCRIPTION
Using `os.path.realpath` instead of `os.path.abspath` allows to follow links that point to real paprica installation path.