### PR TITLE
Update paprica-combine_results.py

### DIFF
--- a/paprica-combine_results.py
+++ b/paprica-combine_results.py
@@ -229,7 +229,7 @@ unique_edge_abund = pd.DataFrame() # index = seqs, cols = edges
 
 unique_tallies = []
 
-for f in os.listdir(cwd).sort():
+for f in sorted(os.listdir(cwd)):
     if f.endswith(unique_suffix):
         print(colored('Tallying ASVs for ' + f, 'green'))
         name = re.sub(unique_suffix, '', f)


### PR DESCRIPTION
The master version of this script gave me the error message `TypeError: 'NoneType' object is not iterable` at line 232. I fixed this error by changing `for f in os.listdir(cwd).sort():` to `for f in sorted(os.listdir(cwd)):`